### PR TITLE
Properly close the meta tag in the scaffolding templates

### DIFF
--- a/src/main/templates/scaffolding/create.gsp
+++ b/src/main/templates/scaffolding/create.gsp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="layout" content="main">
+        <meta name="layout" content="main" />
         <g:set var="entityName" value="\${message(code: '${propertyName}.label', default: '${className}')}" />
         <title><g:message code="default.create.label" args="[entityName]" /></title>
     </head>

--- a/src/main/templates/scaffolding/edit.gsp
+++ b/src/main/templates/scaffolding/edit.gsp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="layout" content="main">
+        <meta name="layout" content="main" />
         <g:set var="entityName" value="\${message(code: '${propertyName}.label', default: '${className}')}" />
         <title><g:message code="default.edit.label" args="[entityName]" /></title>
     </head>

--- a/src/main/templates/scaffolding/index.gsp
+++ b/src/main/templates/scaffolding/index.gsp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="layout" content="main">
+        <meta name="layout" content="main" />
         <g:set var="entityName" value="\${message(code: '${propertyName}.label', default: '${className}')}" />
         <title><g:message code="default.list.label" args="[entityName]" /></title>
     </head>

--- a/src/main/templates/scaffolding/show.gsp
+++ b/src/main/templates/scaffolding/show.gsp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="layout" content="main">
+        <meta name="layout" content="main" />
         <g:set var="entityName" value="\${message(code: '${propertyName}.label', default: '${className}')}" />
         <title><g:message code="default.show.label" args="[entityName]" /></title>
     </head>


### PR DESCRIPTION
Each of the following files was improperly closing the meta tag.

create.gsp
edit.gsp
index.gsp
show.gsp
